### PR TITLE
Include createActionCreator in index.js

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@
 
 export * from './types';
 export * from './helpers';
+export * from './create-action-creator';
+
 
 // workarounds for missing features
 export * from './returntypeof';


### PR DESCRIPTION
Allows for convenient import, e.g.

```
import { createActionCreator } from 'react-redux-typescript';
```